### PR TITLE
Changed Run2 lumi values and lumi uncertainties for 2017, 2018. Addresses ram1123#178

### DIFF
--- a/configs/datasets/dataset_nanoAODv12_run2.yaml
+++ b/configs/datasets/dataset_nanoAODv12_run2.yaml
@@ -1,7 +1,7 @@
 years:
   "2018PR":
     Data:
-      total_lumi_pb: 59830.0
+      total_lumi_pb: 59560.0
       data_A:
         skip_sample: False
         datasets:
@@ -56,7 +56,7 @@ years:
 
   "2018":
     Data:
-      total_lumi_pb: 59830.0
+      total_lumi_pb: 59560.0
       data_A:
         skip_sample: False
         datasets:
@@ -409,7 +409,7 @@ years:
 
   "2017":
     Data:
-      total_lumi_pb: 41480.0
+      total_lumi_pb: 42700.0
       data_B:
         skip_sample: False
         datasets:

--- a/configs/datasets/dataset_nanoAODv15_run2.yaml
+++ b/configs/datasets/dataset_nanoAODv15_run2.yaml
@@ -1,7 +1,61 @@
 years:
+    "2018PR":
+        Data:
+          total_lumi_pb: 59560.0
+          data_A:
+            skip_sample: False
+            datasets:
+              - /depot/cms/hmm/shar1172/Small_NanoAOD_ForValidtionPR/UL2018/SingleMuon_Run2018A
+            lumi_pb: null
+            das_request: "local customNanoAOD, no DAS"
+            parent_das: todo
+            golden_json: data/lumimasks/Cert_314472-325175_13TeV_Legacy2018_Collisions18_JSON.txt
+            references:
+              - null
+        
+        DY:
+          dy_M-100To200_aMCatNLO:
+            skip_sample: False
+            datasets:
+              - /depot/cms/hmm/shar1172/Small_NanoAOD_ForValidtionPR/UL2018/DYJetsToLL_M-100to200_TuneCP5_13TeV-amcatnloFXFX-pythia8
+            cross_section_pb: 233.8592627
+            cross_section_source: None
+            kfactor:
+              value: 1.0
+              source: null
+            filter_efficiency: 1.0
+            references:
+              - null
+        
+        Higgs:
+          vbf_powheg_dipole:
+            skip_sample: False
+            datasets:
+              - /depot/cms/hmm/shar1172/Small_NanoAOD_ForValidtionPR/UL2018/VBFHToMuMu_M125_TuneCP5_withDipoleRecoil_13TeV-powheg-pythia8
+            cross_section_pb: null
+            cross_section_source: null
+            kfactor:
+              value: 1.0
+              source: null
+            filter_efficiency: 1.0
+            references:
+              - null
+        
+          ggh_powhegPS:
+            skip_sample: False
+            datasets:
+              - /depot/cms/hmm/shar1172/Small_NanoAOD_ForValidtionPR/UL2018/GluGluHToMuMu_M125_TuneCP5_13TeV-powheg-pythia8
+            cross_section_pb: null
+            cross_section_source: null
+            kfactor:
+              value: 1.0
+              source: null
+            filter_efficiency: 1.0
+            references:
+              - null
     "2017":
         Data:
-            total_lumi_pb: 41480.0
+            total_lumi_pb: 42700.0
             data_B:
                 skip_sample: False
                 datasets:
@@ -640,7 +694,7 @@ years:
                 - null
     "2018": # FIXME: From here onwards below is the automated version of chatGPT from codimd doc (https://codimd.web.cern.ch/aK_Yxu91QHqpsjeWaa4aIw#Parts-missing). So there's a good chance that there's errors
       Data:
-        total_lumi_pb: 59830.0
+        total_lumi_pb: 59560.0
         data_A:
           skip_sample: False
           datasets:

--- a/configs/parameters/lumi.yaml
+++ b/configs/parameters/lumi.yaml
@@ -4,8 +4,8 @@ integrated_lumis: # source: https://github.com/TopEFT/topeft/blob/252c6454e06e49
   '2018_RERECO': 59740.0
   '2016preVFP': 19500.0
   '2016postVFP': 16810.0
-  '2017': 41480.0
-  '2018': 59830.0
+  '2017': 42700.0
+  '2018': 59560.0
   '2022preEE': 7990.0
   '2022postEE': 26680.70
   "2023": 17960.0 # https://docs.google.com/presentation/d/1TjPem5jX0fzqvTGl271_nQFoVBabsrdrO0i8Qo1uD5E/edit?slide=id.g289f499aa6b_2_58#slide=id.g289f499aa6b_2_58

--- a/stage2/ggH_datacard/generate_datacard.py
+++ b/stage2/ggH_datacard/generate_datacard.py
@@ -224,11 +224,15 @@ pdf_Higgs_qq     lnN     -            1.021        -
 """)# QCD and pdf Source table 2.1 from AN-19-124. Lumi source: https://twiki.cern.ch/twiki/bin/viewauth/CMS/LumiRecommendationsRun2
         
     if year == "2016":
-        lines.append("lumi_13TeV_2016       lnN     1.012       1.012       -")
+        lines.append("lumi_13TeV_2016       lnN     1.012       1.012       -") #FIXME: not following the official recommendation. This is just a placeholder
     elif year == "2017":
-        lines.append("lumi_13TeV_2017       lnN     1.023       1.0082       -")
+        lines.append("lumi_13TeV_2017       lnN     1.023       1.0082       -") #FIXME: not following the official recommendation. This is just a placeholder
     elif year == "2018":
-        lines.append("lumi_13TeV_2018       lnN     1.025       1.0084       -")
+        lines.append("lumi_13TeV_2018       lnN     1.025       1.0084       -") #FIXME: not following the official recommendation. This is just a placeholder
+    elif year == "run2": # all years in Run2: 2016preVFP, 2016postVFP, 2017, 2018
+        lines.append("lumi_13TeV_1516_l       lnN     1.0031      1.0031      -")
+        lines.append("lumi_13TeV_151617_l     lnN     1.0018      1.0018      -")
+        lines.append("lumi_13TeV_15161718_l   lnN     1.0064      1.0064      -")
     elif "2022" in year:
         lines.append("lumi_13p6TeV_Corr     lnN     1.0138      1.0138      -")
     elif "2023" in year:
@@ -238,7 +242,7 @@ pdf_Higgs_qq     lnN     -            1.021        -
         lines.append("lumi_13p6TeV_Corr     lnN     1.0020      1.0020      -")
         lines.append("lumi_13p6TeV_23_24    lnN     1.0068      1.0068      -")
         lines.append("lumi_13p6TeV_uncorr   lnN     1.0144      1.0144      -")
-    elif year == "all":
+    elif year == "run3": # all years in Run3: 2022preEE, 2022postEE, 2023, 2023BPix, 2024
         lines.append("lumi_13p6TeV_Corr     lnN     1.0020      1.0020      -")
         lines.append("lumi_13p6TeV_23_24    lnN     1.0068      1.0068      -")
         lines.append("lumi_13p6TeV_uncorr   lnN     1.0144      1.0144      -")

--- a/stage2/ggH_datacard/generate_datacard.py
+++ b/stage2/ggH_datacard/generate_datacard.py
@@ -226,9 +226,9 @@ pdf_Higgs_qq     lnN     -            1.021        -
     if year == "2016":
         lines.append("lumi_13TeV_2016       lnN     1.012       1.012       -")
     elif year == "2017":
-        lines.append("lumi_13TeV_2017       lnN     1.023       1.023       -")
+        lines.append("lumi_13TeV_2017       lnN     1.023       1.0082       -")
     elif year == "2018":
-        lines.append("lumi_13TeV_2018       lnN     1.025       1.025       -")
+        lines.append("lumi_13TeV_2018       lnN     1.025       1.0084       -")
     elif "2022" in year:
         lines.append("lumi_13p6TeV_Corr     lnN     1.0138      1.0138      -")
     elif "2023" in year:

--- a/stage3/make_datacards.py
+++ b/stage3/make_datacards.py
@@ -77,7 +77,7 @@ rate_syst_lookup = {
         "XsecAndNormggH": {"ggH": 1.38313},
     },
 }
-lumi_syst = {
+lumi_syst = { # NOTE: values are in percent, NOTE: lumi values source: "For analyses using the three or four years integrated" https://twiki.cern.ch/twiki/bin/viewauth/CMS/LumiRecommendationsRun2
     "2016": {
         # "uncor2016": 2.2,
         # "xyfac": 0.9,
@@ -86,7 +86,9 @@ lumi_syst = {
         # "beta": 0.5,
         # "calib": 0.0,
         # "ghost": 0.4,
-        "lumi2016": 1.2,
+        "lumi_13TeV_1516_l":  0.31,
+        "lumi_13TeV_151617_l":  0.18,
+        "lumi_13TeV_15161718_l":  0.64,
     },
     "2017": {
         # "uncor2017": 2.0,
@@ -96,7 +98,9 @@ lumi_syst = {
         # "beta": 0.5,
         # "calib": 0.3,
         # "ghost": 0.1,
-        "lumi2017": 2.3,
+        "lumi_13TeV_1516_l":  0.31,
+        "lumi_13TeV_151617_l":  0.18,
+        "lumi_13TeV_15161718_l":  0.64,
     },
     "2018": {
         # "uncor2018": 1.5,
@@ -106,7 +110,9 @@ lumi_syst = {
         # "beta": 0.0,
         # "calib": 0.2,
         # "ghost": 0.0,
-        "lumi2018": 2.5,
+        "lumi_13TeV_1516_l":  0.31,
+        "lumi_13TeV_151617_l":  0.18,
+        "lumi_13TeV_15161718_l":  0.64,
     },
     # Updated the lumi values from here: https://twiki.cern.ch/twiki/bin/view/CMS/LumiRecommendationsRun3#2024
     # FIXME: WE should send this at a centralized YAML file


### PR DESCRIPTION
For 2016 lumi values and lumi uncertainties, they were fine.